### PR TITLE
Remove idea of default state property value

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,13 +144,13 @@ In this example, `Memoize` is used to create a `memoize` function associated wit
 
 **`StateProperty({ state, setState })`**
 
-The `StateProperty` function is factory function that creates a utility that simplifies the management of individual properties within a state object. It returns a function that allows easy access to a specific state property's value and provides a setter function to update that property. This is particularly useful in complex applications where state is passed down through various components or functions.
+The `StateProperty` function is factory function that creates a utility that simplifies the management of individual properties within a state object. It returns a function that allows easy access to a specific state property's value and provides a setter function to update that property.
 
 ```js
 const stateProperty = StateProperty({ state, setState });
 ```
 
-**`stateProperty(fieldName[,defaultValue])`**
+**`stateProperty(fieldName)`**
 
 The `stateProperty` function, created by the `StateProperty` factory function, binds to a specific property in the state. It returns an array with two elements: the current value of the field and a setter function to update that field. This pattern enables you to manage stateful values in a concise and intuitive way, ensuring that your D3 visualizations remain responsive to changes in state. This pattern is similar to React's `useState` hook.
 

--- a/src/StateProperty.js
+++ b/src/StateProperty.js
@@ -1,9 +1,10 @@
 export const StateProperty =
   ({ state, setState }) =>
-  (field, defaultValue) => [
-    state[field] === undefined
-      ? defaultValue
-      : state[field],
+  (propertyName) => [
+    state[propertyName],
     (value) =>
-      setState((state) => ({ ...state, [field]: value })),
+      setState((state) => ({
+        ...state,
+        [propertyName]: value,
+      })),
   ];

--- a/src/StateProperty.test.js
+++ b/src/StateProperty.test.js
@@ -14,12 +14,15 @@ test('stateField returns the correct state value and setter function', () => {
       state,
       setState,
     });
-    const [name, setName] = stateProperty('name', 'Alice');
+    const [name, setName] = stateProperty('name');
     current.name = name;
     current.setName = setName;
   };
 
   main();
+  expect(current.name).toBe(undefined);
+
+  current.setName('Alice');
   expect(current.name).toBe('Alice');
 
   current.setName('Bob');


### PR DESCRIPTION
This PR removes the idea of default state property value, in an effort to make the library as simple as possible.

The idea of a default value introduces complexity that may not be needed.

We may want to bring this back when the need for having a default value it is more clear.