### PR TITLE
Cleaner API for observeResize

### DIFF
--- a/src/observeResize.js
+++ b/src/observeResize.js
@@ -1,11 +1,22 @@
-import { StateField } from './StateField';
+import { StateField } from 'd3-rosetta';
+
 export const observeResize = (container, options) => {
   const [dimensions, setDimensions] =
     StateField(options)('dimensions');
-  if (!dimensions) {
-    new ResizeObserver((entries) => {
-      setDimensions(entries[0].contentRect);
-    }).observe(container);
-  }
-  return dimensions;
+  if (dimensions) return dimensions;
+  const getDimensions = () => ({
+    width: container.clientWidth,
+    height: container.clientHeight,
+  });
+
+  let isFirstCall = true;
+  new ResizeObserver(() => {
+    if (isFirstCall) {
+      isFirstCall = false;
+      return;
+    }
+    setDimensions(getDimensions());
+  }).observe(container);
+
+  return getDimensions();
 };


### PR DESCRIPTION
Before:

```js
  const dimensions = observeResize(container, options);
  if (!dimensions) return;
  const { width, height } = dimensions;
```

After

```js
  const { width, height } = observeResize(container, options);
```