### PR TITLE
V3 Overhaul

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 .gitignore
 .prettierignore
 *.svg
+*.svelte
 dist

--- a/README.md
+++ b/README.md
@@ -93,9 +93,11 @@ const memoize = createMemoize(container);
 The `memoize` function, returned by `createMemoize`, accepts a `callback` function (which performs the expensive computation) and an array of `dependencies`.
 
 - `callback`: A function that computes the value to be memoized.
-- `dependencies`: An array of values. If these values are the same as in the previous call for this specific memoization instance, the cached value is returned. Otherwise, the `callback` is executed, and its result is cached and returned.
+- `dependencies`: An array of values. If these dependency values are strictly equal (`===`) to the dependencies from the previous call for this specific memoization instance, the cached value is returned. Otherwise, the `callback` is executed, and its result is cached and returned.
 
 This pattern is similar to React's `useMemo` hook and is particularly useful for computationally intensive data processing or DOM rendering operations.
+
+#### Example:
 
 ```js
 import { createMemoize } from 'd3-rosetta';
@@ -171,14 +173,14 @@ The `unidirectionalDataFlow` function is a core utility that establishes and man
 - **`viz`**: A function that encapsulates the rendering logic of the visualization. This function is called by `unidirectionalDataFlow` initially and every time the state is updated. It receives three arguments:
   - `container`: The same `container` object passed to `unidirectionalDataFlow`.
   - `state`: An object representing the current state of the application. It is initialized as an empty object `{}` by `unidirectionalDataFlow`.
-  - `setState`: A function to update the state. It accepts a callback function that receives the previous state and should return the new state (e.g., `setState(prevState => ({ ...prevState, newProperty: 'value' }))`). Invoking `setState` triggers `unidirectionalDataFlow` to re-execute the `viz` function with the updated state.
+  - `setState`: A function to update the state. It accepts a callback function that receives the previous state and should return the new state using [immutable update patterns](https://redux.js.org/usage/structuring-reducers/immutable-update-patterns) (e.g., `setState(prevState => ({ ...prevState, newProperty: 'value' }))`). Invoking `setState` triggers `unidirectionalDataFlow` to re-execute the `viz` function with the updated state.
 
 #### How it Works:
 
 1.  `unidirectionalDataFlow` initializes an internal `state` variable to an empty object (`{}`).
 2.  It defines a `setState` function. When this `setState(nextStateFn)` is called:
     a. The new state is computed: `state = nextStateFn(state)`.
-    b. The `viz` function is called again with the updated `state`: `viz(container, state, setState)`.
+    b. The `viz` function is called again with the `container`, the newly updated `state`, and the same (stable) `setState` function: `viz(container, state, setState)`.
 3.  Initially, `unidirectionalDataFlow` calls `viz(container, state, setState)` once to perform the first render with the initial empty state.
 
 This utility is fundamental for structuring D3 (or other rendering library) visualizations in a way that is self-contained and can be easily integrated into various JavaScript frameworks or run in a vanilla JavaScript environment. For a more detailed explanation of the pattern itself, see [The Solution: Unidirectional Data Flow](#the-solution-unidirectional-data-flow).

--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ While frameworks like React, Svelte, Vue, and Angular offer state management and
 Unidirectional data flow is a pattern that can be cleanly invoked from multiple frameworks. In this paradigm, a single function is responsible for updating the DOM or rendering visuals based on a single, central state. As the state updates, the function re-renders the visualization in an idempotent manner, meaning it can run multiple times without causing side effects. Here's what the entry point function looks like for a D3-based visualization that uses unidirectional data flow:
 
 ```js
-export const viz = (container, { state, setState }) => {
+export const viz = (container, state, setState) => {
   // Your reusable D3-based rendering logic goes here
 };
 ```
 
-- **`container`**: A DOM element where the visualization will be rendered
-- **`state`**: An object representing the current state of the application, initially empty
-- **`setState`**: A function that updates the state using immutable update patterns
+- **`container`**: A DOM element where the visualization will be rendered.
+- **`state`**: An object representing the current state of the application. It is initialized as an empty object `{}` by `unidirectionalDataFlow`.
+- **`setState`**: A function to update the state. It accepts a callback function that receives the previous state and should return the new state (e.g., `setState(prevState => ({ ...prevState, newProperty: 'value' }))`). Invoking `setState` triggers `unidirectionalDataFlow` to re-execute the `viz` function with the updated state.
 
 Whenever `setState` is invoked, `viz` re-executes with the new state, ensuring that the rendering logic is both dynamic and responsive. This pattern is implemented in the [VizHub](https://vizhub.com/) runtime environment and can be invoked from different frameworks as needed.
 
@@ -100,7 +100,7 @@ This pattern is similar to React's `useMemo` hook and is particularly useful for
 ```js
 import { createMemoize } from 'd3-rosetta';
 
-export const viz = (container, { state, setState }) => {
+export const viz = (container, state, setState) => {
   const { a, b } = state;
   const memoize = createMemoize(container); // `container` is the DOM node here
   const computed = memoize(() => {
@@ -136,7 +136,7 @@ The `stateField` function (returned by `createStateField`) takes a `propertyName
 ```javascript
 import { createStateField } from 'd3-rosetta';
 
-export const viz = (container, { state, setState }) => {
+export const viz = (container, state, setState) => {
   const stateField = createStateField(state, setState);
 
   const [name, setName] = stateField('name'); // Gets state.name and a setter for state.name
@@ -192,7 +192,7 @@ The example under [Vanilla JS](#vanilla-js) in the Rosetta Stone section also de
 This section provides concrete examples of how to integrate a D3.js visualization using the unidirectional data flow pattern into various JavaScript frameworks and vanilla JavaScript setups. Each example aims to be a minimal, runnable project, typically set up with Vite.
 
 The core visualization logic (referred to as `viz` or `main` in the examples) is assumed to follow the signature:
-`viz(container, { state, setState })`
+`viz(container, state, setState)`
 
 You can find these examples in the `rosetta-stone` directory of this repository:
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dist/"
   ],
   "scripts": {
-    "test": "vitest",
+    "test": "vitest run",
     "prettier": "prettier {*.*,**/*.*} --write",
     "build": "vite build",
     "prepublishOnly": "npm run build"

--- a/src/createMemoize.js
+++ b/src/createMemoize.js
@@ -1,9 +1,8 @@
 export const createMemoize = (node) => {
   let invocationCount = 0;
 
-  const memoize = (callback, dependencies) => {
+  return (callback, dependencies) => {
     const property = `@memoized-${invocationCount++}`;
-
     const memoized = node[property];
 
     if (
@@ -26,6 +25,4 @@ export const createMemoize = (node) => {
     node[property] = { dependencies, value };
     return value;
   };
-
-  return memoize;
 };

--- a/src/createMemoize.test.js
+++ b/src/createMemoize.test.js
@@ -119,6 +119,132 @@ test('multiple invocations on one instance', () => {
   expect(invocationCountBSquared).toBe(3);
 });
 
+test('recomputes if object dependency reference changes, not if content mutates', () => {
+  const container = {};
+  let callCount = 0;
+  let depObj = { val: 1 };
+
+  const run = () => {
+    const memoize = createMemoize(container);
+    return memoize(() => {
+      callCount++;
+      return depObj.val * 2;
+    }, [depObj]);
+  };
+
+  run();
+  expect(callCount).toBe(1);
+
+  // Mutate content, but same reference: should not recompute
+  depObj.val = 2;
+  run();
+  expect(callCount).toBe(1); // Still 1 because depObj reference hasn't changed
+
+  // Change reference, even if content is "same": should recompute
+  depObj = { val: 2 };
+  run();
+  expect(callCount).toBe(2);
+
+  // Change reference to new content: should recompute
+  depObj = { val: 3 };
+  run();
+  expect(callCount).toBe(3);
+});
+
+test('recomputes if array dependency reference changes, not if content mutates', () => {
+  const container = {};
+  let callCount = 0;
+  let depArray = [1];
+
+  const run = () => {
+    const memoize = createMemoize(container);
+    return memoize(() => {
+      callCount++;
+      return depArray[0] * 2;
+    }, [depArray]);
+  };
+
+  run();
+  expect(callCount).toBe(1);
+
+  // Mutate content, but same reference: should not recompute
+  depArray[0] = 2;
+  run();
+  expect(callCount).toBe(1);
+
+  // Change reference, even if content is "same": should recompute
+  depArray = [2];
+  run();
+  expect(callCount).toBe(2);
+
+  // Change reference to new content: should recompute
+  depArray = [3];
+  run();
+  expect(callCount).toBe(3);
+});
+
+test('handles null and undefined dependencies correctly', () => {
+  const container = {};
+  let callCount = 0;
+  let dep = null;
+
+  const run = () => {
+    const memoize = createMemoize(container);
+    return memoize(() => {
+      callCount++;
+      return String(dep);
+    }, [dep]);
+  };
+
+  run(); // dep is null
+  expect(callCount).toBe(1);
+  expect(run()).toBe('null'); // dep is still null
+  expect(callCount).toBe(1);
+
+  dep = undefined;
+  run(); // dep is undefined
+  expect(callCount).toBe(2);
+  expect(run()).toBe('undefined'); // dep is still undefined
+  expect(callCount).toBe(2);
+
+  dep = null;
+  run(); // dep is null again
+  expect(callCount).toBe(3);
+  expect(run()).toBe('null');
+  expect(callCount).toBe(3);
+});
+
+test('recomputes if a dependency was NaN and is still NaN', () => {
+  const container = {};
+  let callCount = 0;
+  let dep = NaN;
+
+  const run = () => {
+    const memoize = createMemoize(container);
+    return memoize(() => {
+      callCount++;
+      return String(dep);
+    }, [dep]);
+  };
+
+  run(); // dep is NaN
+  expect(callCount).toBe(1);
+
+  // dep is still NaN. Because NaN !== NaN is true, it will recompute.
+  run();
+  expect(callCount).toBe(2);
+
+  dep = 1;
+  run();
+  expect(callCount).toBe(3);
+  run(); // dep is still 1
+  expect(callCount).toBe(3);
+
+  dep = NaN;
+  run();
+  expect(callCount).toBe(4);
+});
+
 // test('accepts a D3 selection', () => {
 //   const domNode = {};
 //   let invocationCount = 0;

--- a/src/createStateField.js
+++ b/src/createStateField.js
@@ -2,8 +2,8 @@ export const createStateField =
   (state, setState) => (propertyName) => [
     state[propertyName],
     (value) => {
-      setState((state) => ({
-        ...state,
+      setState((previousState) => ({
+        ...previousState,
         [propertyName]: value,
       }));
     },

--- a/src/createStateField.test.js
+++ b/src/createStateField.test.js
@@ -5,11 +5,9 @@ import { unidirectionalDataFlow } from './unidirectionalDataFlow.js';
 test('createStateField returns the correct state value and setter function using unidirectionalDataFlow', () => {
   const mockContainer = {}; // Mock container for unidirectionalDataFlow
   const testScope = {}; // To store values/setters from viz for assertions
-
   // The viz function will be called by unidirectionalDataFlow on init and after each setState
-  const viz = (container, { state, setState }) => {
+  const viz = (container, state, setState) => {
     const stateField = createStateField(state, setState);
-
     const [name, setName] = stateField('name');
     testScope.name = name;
     testScope.setName = setName;

--- a/src/unidirectionalDataFlow.js
+++ b/src/unidirectionalDataFlow.js
@@ -2,7 +2,7 @@ export const unidirectionalDataFlow = (container, viz) => {
   let state = {};
   const setState = (next) => {
     state = next(state);
-    viz(container, { state, setState });
+    viz(container, state, setState);
   };
-  viz(container, { state, setState });
+  viz(container, state, setState);
 };

--- a/src/unidirectionalDataFlow.test.js
+++ b/src/unidirectionalDataFlow.test.js
@@ -10,13 +10,14 @@ test('unidirectionalDataFlow initializes and updates state', () => {
 
   // Check initial call
   expect(vizMock).toHaveBeenCalledTimes(1);
-  expect(vizMock).toHaveBeenCalledWith(container, {
-    state: {},
-    setState: expect.any(Function),
-  });
+  expect(vizMock).toHaveBeenCalledWith(
+    container,
+    {}, // state
+    expect.any(Function), // setState
+  );
 
   // Get the setState function from the first call's arguments
-  const { setState } = vizMock.mock.calls[0][1];
+  const setState = vizMock.mock.calls[0][2];
 
   // Simulate a state update
   const newState = { count: 1 };
@@ -24,10 +25,11 @@ test('unidirectionalDataFlow initializes and updates state', () => {
 
   // Check if vizMock was called again with the new state
   expect(vizMock).toHaveBeenCalledTimes(2);
-  expect(vizMock).toHaveBeenCalledWith(container, {
-    state: newState,
+  expect(vizMock).toHaveBeenCalledWith(
+    container,
+    newState, // state
     setState,
-  });
+  );
 
   // Simulate another state update
   const newerState = { count: 2 };
@@ -37,10 +39,11 @@ test('unidirectionalDataFlow initializes and updates state', () => {
   }));
 
   expect(vizMock).toHaveBeenCalledTimes(3);
-  expect(vizMock).toHaveBeenCalledWith(container, {
-    state: newerState,
+  expect(vizMock).toHaveBeenCalledWith(
+    container,
+    newerState, // state
     setState,
-  });
+  );
 });
 
 test('unidirectionalDataFlow uses initial state from viz if provided', () => {
@@ -50,7 +53,8 @@ test('unidirectionalDataFlow uses initial state from viz if provided', () => {
   // viz function that sets an initial state if state is empty
   const vizWithInitialState = (
     container,
-    { state, setState },
+    state,
+    setState,
   ) => {
     if (Object.keys(state).length === 0) {
       setState(() => initialVizState);
@@ -63,12 +67,16 @@ test('unidirectionalDataFlow uses initial state from viz if provided', () => {
 
   // Called once for initialization, then once for setState from within viz
   expect(vizSpy).toHaveBeenCalledTimes(2);
-  expect(vizSpy).toHaveBeenNthCalledWith(1, container, {
-    state: {},
-    setState: expect.any(Function),
-  });
-  expect(vizSpy).toHaveBeenNthCalledWith(2, container, {
-    state: initialVizState,
-    setState: expect.any(Function),
-  });
+  expect(vizSpy).toHaveBeenNthCalledWith(
+    1,
+    container,
+    {}, // state
+    expect.any(Function), // setState
+  );
+  expect(vizSpy).toHaveBeenNthCalledWith(
+    2,
+    container,
+    initialVizState, // state
+    expect.any(Function), // setState
+  );
 });


### PR DESCRIPTION
After using the new V2 API, some inconsistencies became glaringly obvious.

This set of changes focuses mainly on removing unnecessary use of the options object pattern, instead preferring traditional argument lists.